### PR TITLE
Version bump to 0.9.0

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="2">
   <name>warehouse_ros_sqlite</name>
-  <version>1.0.0</version>
+  <version>0.9.0</version>
   <description>
     Implementation of warehouse_ros for sqlite
   </description>

--- a/warehouse_ros.rosinstall
+++ b/warehouse_ros.rosinstall
@@ -1,4 +1,4 @@
 - git:
     local-name: warehouse_ros
     uri: https://github.com/ros-planning/warehouse_ros.git
-    version: kinetic-devel
+    version: heads/kinetic-devel


### PR DESCRIPTION
Version bump backwards to 0.9.0

To distinguish between ROS1 and ROS2, the ROS1 version major stays at 0.