### PR TITLE
[Don't Merge] Release 1.0.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog for package warehouse_ros_sqlite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+Forthcoming
+-----------
+* Add humble testing CI (`#37 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/37>`_)
+* add missing stdlib include
+* disable header include order check
+* don't build warehouse_ros from source
+* Contributors: Bjar Ne, Vatan Aksoy Tezer
+
 1.0.2 (2021-10-12)
 ------------------
 * Update CMakeLists.txt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,8 +2,8 @@
 Changelog for package warehouse_ros_sqlite
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-Forthcoming
------------
+1.0.3 (2022-05-17)
+------------------
 * Add humble testing CI (`#37 <https://github.com/ros-planning/warehouse_ros_sqlite/issues/37>`_)
 * add missing stdlib include
 * disable header include order check

--- a/package.xml
+++ b/package.xml
@@ -1,6 +1,6 @@
 <package format="3">
   <name>warehouse_ros_sqlite</name>
-  <version>1.0.2</version>
+  <version>1.0.3</version>
   <description>
     Implementation of warehouse_ros for sqlite
   </description>


### PR DESCRIPTION
Humble build farm has been failing, with a missing header: https://build.ros2.org/job/Hbin_uJ64__warehouse_ros_sqlite__ubuntu_jammy_amd64__binary/. This has been fixed with 8a2cb26587c51474afab24d945bd1a6c6a86f714 and should be released again. I've added humble testing job in a previous PR and it looks happy.